### PR TITLE
Create and test git hook, update readme

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This commit-msg hook blocks commits that expose private emails in the commit message
+# Allowed: emails containing 'noreply' or ending with 'placeholder.com'
+
+COMMIT_MSG_FILE="$1"
+
+if [ ! -f "$COMMIT_MSG_FILE" ]; then
+  echo "❌ Commit blockiert: Commit-Nachrichtendatei nicht gefunden."
+  exit 1
+fi
+
+if grep -Eio '[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}' "$COMMIT_MSG_FILE" \
+  | grep -Evi 'noreply|placeholder\.com'; then
+  echo '❌ Commit blockiert: Private E-Mail in Commit-Nachricht (inkl. Trailern) gefunden.'
+  echo 'Bitte nur noreply- oder placeholder.com-Adressen verwenden.'
+  exit 1
+fi
+
+exit 0

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 **NIEMALS meine private E-Mail-Adresse als Co-Autor in Git-Commits veröffentlichen!**
 
 ### Verboten:
-- `Co-authored-by: Name <ihre-echte-email@gmail.com>`
-- `Co-authored-by: Name <ihre-echte-email@web.de>`
+- `Co-authored-by: Name <ihre-echte-email@example.com>`
 - Jede andere private E-Mail-Adresse
 
 ### Erlaubt:


### PR DESCRIPTION
# Pull Request für Brezn

## 🚨 WICHTIG: Keine privaten E-Mail-Adressen veröffentlichen! 🚨

**Bevor Sie diesen PR erstellen, stellen Sie sicher, dass:**
- [x] **KEINE privaten E-Mail-Adressen im Code enthalten sind**
- [x] **KEINE E-Mail-Adressen als Co-Author in Commits hinzugefügt wurden**
- [x] **Nur generische Benutzernamen ohne E-Mail-Domains verwendet werden**
- [x] **Alle E-Mail-Adressen durch Platzhalter wie "user@placeholder.com" ersetzt wurden**

## Beschreibung der Änderungen
- Neuer `commit-msg` Git-Hook hinzugefügt, um private E-Mail-Adressen in Commit-Nachrichten (inkl. Co-Authors) zu verhindern. Erlaubt sind `noreply` und `placeholder.com`.
- `README.md` aktualisiert: `web.de` und `gamil` E-Mail-Beispiele durch `example.com` ersetzt.
- `core.hooksPath` auf `.githooks` konfiguriert, um die Hooks zu aktivieren.

## Art der Änderung
- [ ] Bugfix
- [x] Neue Funktion
- [ ] Breaking Change
- [x] Dokumentation
- [ ] Refactoring
- [ ] Test
- [ ] Build/CI

## Betroffene Bereiche
- `.githooks/commit-msg`
- `README.md`
- Git-Konfiguration (lokales `core.hooksPath`)

## Tests
- [ ] Alle Tests bestehen
- [ ] Neue Tests für neue Funktionalität hinzugefügt
- [x] Manuelle Tests durchgeführt (Commit mit verbotener E-Mail wurde blockiert, erlaubte E-Mails und keine E-Mails wurden zugelassen).

## Checkliste
- [x] Code folgt den Codierungsstandards des Projekts
- [x] Dokumentation aktualisiert (falls nötig)
- [x] Keine privaten Daten oder E-Mail-Adressen veröffentlicht
- [x] Build erfolgreich (`cargo build`, `cargo test`)
- [x] Keine Compiler-Warnungen

## Zusätzliche Notizen
Der neue `commit-msg`-Hook ist analog zur bestehenden `pre-push`-Policy, um eine konsistente E-Mail-Richtlinie über den gesamten Git-Workflow hinweg zu gewährleisten.

## Sicherheitshinweise
**Dieser PR enthält KEINE:**
- Private E-Mail-Adressen
- Passwörter oder API-Schlüssel
- Persönliche Daten von Benutzern
- Co-Authors mit E-Mail-Adressen

---
<a href="https://cursor.com/background-agent?bcId=bc-02ea921d-6541-494e-a061-11fd3e726f5e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-02ea921d-6541-494e-a061-11fd3e726f5e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

