### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/src/lib/nostrClient.test.ts
+++ b/src/lib/nostrClient.test.ts
@@ -137,7 +137,13 @@ describe('nostrClient relays', () => {
     expect(relays).toContain('wss://relay.example.com')
     expect(relays).not.toContain('wss://relay.example.com/') // trailing slash removed
     // ws:// is actually accepted (for local testing), so we check it's normalized
-    expect(relays.some(r => r.includes('relay.example.com'))).toBe(true)
+    expect(
+      relays.some(
+        r =>
+          r.startsWith('wss://relay.example.com') ||
+          r.startsWith('ws://relay.example.com'),
+      ),
+    ).toBe(true)
     expect(relays).not.toContain('invalid-url')
     expect(relays).not.toContain('https://not-ws.com')
   })


### PR DESCRIPTION
Potential fix for [https://github.com/DaBena/Brezn/security/code-scanning/1](https://github.com/DaBena/Brezn/security/code-scanning/1)

In general, to fix incomplete URL substring sanitization, you should avoid scanning the whole URL string for a substring and instead either (a) parse the URL and compare its `hostname` (and scheme, if relevant) to an allowlist, or (b) if parsing is overkill for the context, at least use a strict prefix/host pattern that cannot be bypassed by extra prefix/suffix text.

For this specific test, we are not performing security validation; we just want to assert that at least one relay is a normalized URL for `relay.example.com`, where both `wss://relay.example.com` and a normalized `ws://relay.example.com` should be accepted. We can keep the behavior without relying on `includes` by either parsing `new URL(r)` and checking `hostname === 'relay.example.com'`, or more simply asserting that the string starts with one of the two expected prefixes: `wss://relay.example.com` or `ws://relay.example.com`. Since earlier in the test we already assert that `'wss://relay.example.com'` is present, the main additional check is that any `ws://relay.example.com` entry gets normalized consistently; so we can change the `includes` assertion to a `startsWith`‑based predicate. This requires only updating the single line in `src/lib/nostrClient.test.ts` (line 140) and does not require new imports or changes to other files.

Concretely: in `src/lib/nostrClient.test.ts`, replace `expect(relays.some(r => r.includes('relay.example.com'))).toBe(true)` with a stricter condition like `expect(relays.some(r => r.startsWith('wss://relay.example.com') || r.startsWith('ws://relay.example.com'))).toBe(true)`. That keeps the test’s intention (confirm that at least one relay for that host remains) while avoiding a substring search that could spuriously match other hosts.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
