### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/zapstore-publish.yml
+++ b/.github/workflows/zapstore-publish.yml
@@ -1,6 +1,8 @@
 # Publishes the APK from the latest GitHub release to Zapstore.
 # Runs after build-apk creates a release (or on manual run).
 name: Publish to Zapstore
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/DaBena/Brezn/security/code-scanning/5](https://github.com/DaBena/Brezn/security/code-scanning/5)

In general, the fix is to explicitly declare a least‑privilege `permissions` block either at the workflow root (applies to all jobs) or under the specific job. Since there is only one job (`publish`), either location works, but a root‑level block best documents the workflow’s needs.

This job does not appear to need any write access to the repository; it just checks out code and runs an external CLI. To follow the CodeQL recommendation, we can safely set `permissions: contents: read` at the workflow root, just under `name:` and before `on:`. This will ensure `GITHUB_TOKEN` has read‑only access to repository contents and no broader rights, and it won’t change existing behavior because the job does not perform any write actions via the GitHub API.

Concretely, in `.github/workflows/zapstore-publish.yml`, insert:

```yaml
permissions:
  contents: read
```

between line 3 (`name: Publish to Zapstore`) and line 5 (`on:`). No imports or additional methods are needed, as this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
