### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete URL substring sanitization

### DIFF
--- a/src/lib/nostrClient.test.ts
+++ b/src/lib/nostrClient.test.ts
@@ -146,9 +146,17 @@ describe('nostrClient relays', () => {
     expect(relays).not.toContain('wss://relay.example.com/') // trailing slash removed
     // ws:// is actually accepted (for local testing), so we check it's normalized
     expect(
-      relays.some(
-        (r) => r.startsWith('wss://relay.example.com') || r.startsWith('ws://relay.example.com'),
-      ),
+      relays.some((r) => {
+        try {
+          const u = new URL(r)
+          return (
+            u.hostname === 'relay.example.com' &&
+            (u.protocol === 'wss:' || u.protocol === 'ws:')
+          )
+        } catch {
+          return false
+        }
+      }),
     ).toBe(true)
     expect(relays).not.toContain('invalid-url')
     expect(relays).not.toContain('https://not-ws.com')


### PR DESCRIPTION
Potential fix for [https://github.com/DaBena/Brezn/security/code-scanning/7](https://github.com/DaBena/Brezn/security/code-scanning/7)

The fix is to avoid substring/prefix URL validation and instead parse each relay as a URL, then assert against the parsed `protocol` and `hostname`.

Best single fix in `src/lib/nostrClient.test.ts`:
- In the `"normalizes relay URLs"` test, replace the `startsWith(...)` checks inside `relays.some(...)` with a safe parsed check:
  - `new URL(r)` in a guarded block (`try/catch`)
  - ensure `hostname === 'relay.example.com'`
  - ensure protocol is either `ws:` or `wss:`
- This preserves existing functionality (accept either ws/wss normalized relay for the same host) while removing incomplete substring sanitization.
- No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
